### PR TITLE
Add missing string placeholder in string format

### DIFF
--- a/src/main/java/io/percy/selenium/Environment.java
+++ b/src/main/java/io/percy/selenium/Environment.java
@@ -81,6 +81,6 @@ class Environment {
     }
 
     // We don't know this type of driver. Report its classname as environment info.
-    return String.format("selenium-java; unknownDriver; %", innerDriver.getClass().getName());
+    return String.format("selenium-java; unknownDriver; %s", innerDriver.getClass().getName());
   }
 }


### PR DESCRIPTION
We don't have a test case that would catch this situation, since this is the "unexpected WebDriver type" path, and I'm not convinced it's worth adding right now.

Fixes https://github.com/percy/percy-java-selenium/issues/7
