### PR TITLE
Test OpenJDK LTS versions: 8 and 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   openjdk_8_with_percy:
     # We've opted this OpenJDK version to be the one that runs and reports Percy's status
     docker:
-      - image: circleci/openjdk:10-node-browsers
+      - image: circleci/openjdk:8-node-browsers
     <<: *default_steps
   openjdk_11:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,27 @@
-version: 2
+version: 2.1
+
+default_steps: &default_steps
+  steps:
+    - checkout
+    - run: npm ci
+    - run: ./run-snapshots.sh
+
 jobs:
-  build:
+  openjdk_8_with_percy:
+    # We've opted this node version to be the one that runs and reports Percy's status
     docker:
-      - image: circleci/openjdk:8-node-browsers
-    steps:
-      - checkout
-      - run: npm install
-      - run: ./run-snapshots.sh
+      - image: circleci/openjdk:10-node-browsers
+    <<: *default_steps
+  openjdk_11:
+    docker:
+      - image: circleci/openjdk:11-node-browsers
+    environment:
+      PERCY_ENABLE: 0
+    <<: *default_steps
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - openjdk_8_with_percy
+      - openjdk_11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,12 @@ jobs:
   openjdk_8_with_percy:
     # We've opted this OpenJDK version to be the one that runs and reports Percy's status
     docker:
+      # OpenJDK 8. Node 10.
       - image: circleci/openjdk:8-node-browsers
     <<: *default_steps
   openjdk_11:
     docker:
+      # OpenJDK 11. Node 10.
       - image: circleci/openjdk:11-node-browsers
     environment:
       PERCY_ENABLE: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ default_steps: &default_steps
 
 jobs:
   openjdk_8_with_percy:
-    # We've opted this node version to be the one that runs and reports Percy's status
+    # We've opted this OpenJDK version to be the one that runs and reports Percy's status
     docker:
       - image: circleci/openjdk:10-node-browsers
     <<: *default_steps


### PR DESCRIPTION
See table here https://en.wikipedia.org/wiki/Java_version_history

I've opted for Percy to run on 8 not 11 because 8 is where the majority of people are at the moment.