### PR TITLE
fix: Resource leak problems with HttpClient & InputStream (rebased)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,31 +100,6 @@
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.1.0</version>
       </plugin>
-      <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/classes</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${basedir}/node_modules/@percy/agent/dist/public/</directory>
-                  <includes>
-                    <include>percy-agent.js</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/io/percy/selenium/Environment.java
+++ b/src/main/java/io/percy/selenium/Environment.java
@@ -32,8 +32,8 @@ class Environment {
     // Try to read the artifactId and version from the Jar's properties file.
     InputStream propsStream = getClass().getClassLoader().getResourceAsStream(PROPS_PATH);
     if (propsStream != null) {
-      BufferedReader reader = new BufferedReader(new InputStreamReader(propsStream));
-      try {
+      try (InputStreamReader streamReader = new InputStreamReader(propsStream);
+          BufferedReader reader = new BufferedReader(streamReader)) {
         while (reader.ready()) {
           String line = reader.readLine();
           String[] lineParts = line.split("=");

--- a/src/main/java/io/percy/selenium/Percy.java
+++ b/src/main/java/io/percy/selenium/Percy.java
@@ -3,11 +3,11 @@ package io.percy.selenium;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.apache.http.client.HttpClient;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import org.json.JSONObject;
@@ -65,9 +65,7 @@ public class Percy {
      */
     @Nullable
     private String loadPercyAgentJs() {
-        HttpClient httpClient = HttpClientBuilder.create().build();
-
-        try {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
             //Creating a HttpGet object
             HttpGet httpget = new HttpGet("http://localhost:5338/percy-agent.js");
 
@@ -199,9 +197,8 @@ public class Percy {
         }
 
         StringEntity entity = new StringEntity(json.toString(), ContentType.APPLICATION_JSON);
-        HttpClient httpClient = HttpClientBuilder.create().build();
 
-        try {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
             HttpPost request = new HttpPost("http://localhost:5338/percy/snapshot");
             request.setEntity(entity);
             // We don't really care about the response -- as long as their test suite doesn't fail


### PR DESCRIPTION
1. Fix resource leak by using try-with-resources for `HttpClient`
2. Fix resource leak by using try-with-resources for `InputStream`
3. Stop packaging `percy-agent.js` into the built artifact (.jar file)

I think 3 is necessary because #44 makes this module loading `percy-agent.js` from the server.
This change makes `pom.xml` enough simple.