### PR TITLE
Remove the needless dependency on Selenium

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
       <version>3.141.59</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>


### PR DESCRIPTION
User of this module is expected to have a dependency on Selenium,
then this module can switch to [the provided scope](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html\#Dependency_Scope).

This change will solve the dependency conflict, which might cause unexpected Selenium version.