### PR TITLE
Changed package of WrapsDriver class. 

### DIFF
--- a/src/main/java/io/percy/selenium/Environment.java
+++ b/src/main/java/io/percy/selenium/Environment.java
@@ -1,15 +1,14 @@
 package io.percy.selenium;
 
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WrapsDriver;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.HasCapabilities;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.internal.WrapsDriver;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
 /**
  * Package-private class to compute Environment information.


### PR DESCRIPTION
# Percy is not compatibile with Selenium 4 because WrapsDriver has been removed from package _org.openqa.selenium.internal_ (marked as **Deprecated** since Selenium v. 3.14.0). 
# By this change new Percy java version will be compatible with Selenium v. 3.14.0 and later