### PR TITLE
🐛  Fix getting loglevel env var (prevent null exceptions)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
         <version>1.6</version>
         <configuration>
           <useAgent>true</useAgent>
+          <skip>true</skip>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/io/percy/selenium/Percy.java
+++ b/src/main/java/io/percy/selenium/Percy.java
@@ -40,7 +40,7 @@ public class Percy {
     private String PERCY_SERVER_ADDRESS = System.getenv().getOrDefault("PERCY_SERVER_ADDRESS", "http://localhost:5338");
 
     // Determine if we're debug logging
-    private boolean PERCY_DEBUG = System.getenv("PERCY_LOGLEVEL").equals("debug");
+    private boolean PERCY_DEBUG = System.getenv().getOrDefault("PERCY_LOGLEVEL", "info").equals("debug");
 
     // for logging
     private String LABEL = "[\u001b[35m" + (PERCY_DEBUG ? "percy:java" : "percy") + "\u001b[39m]";


### PR DESCRIPTION
## What is this?

I forgot to grab the log level env var with a default. When running your java tests without `percy exec` (which sets the env var), the tests would blow up with a null pointer exception (the env var was null). 

`<skip>true</skip>` was added to the GPG signing dep so you can install & compile without having to sign the package (only needed for release). 